### PR TITLE
adds nsis to windows-2025

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -288,7 +288,9 @@ jobs:
           distribution: Ubuntu-18.04
 
       - name: Install WSL dependencies
-        run: apt update && apt install -y make autoconf unzip nsis
+        run: |
+          apt update && apt install -y make autoconf unzip
+          winget install -e --id NSIS.NSIS
 
       - name: Install openssl
         shell: cmd

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -279,7 +279,7 @@ jobs:
     env:
       WXWIDGETS_VERSION: 3.2.6
     name: Build Erlang/OTP (Windows)
-    runs-on: windows-2022
+    runs-on: windows-2025
     needs: pack
     if: needs.pack.outputs.build-c-code == 'true'
     steps:
@@ -288,7 +288,7 @@ jobs:
           distribution: Ubuntu-18.04
 
       - name: Install WSL dependencies
-        run: apt update && apt install -y make autoconf unzip
+        run: apt update && apt install -y make autoconf unzip nsis
 
       - name: Install openssl
         shell: cmd

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -290,7 +290,11 @@ jobs:
       - name: Install WSL dependencies
         run: |
           apt update && apt install -y make autoconf unzip
-          winget install -e --id NSIS.NSIS
+
+      - name: Install NSIS
+        shell: cmd
+        run: |
+          choco install nsis --version 3.11.0
 
       - name: Install openssl
         shell: cmd

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -351,6 +351,7 @@ jobs:
 
       - name: Compile Erlang
         run: |
+          export PATH="/mnt/c/Program\ Files\ (x86)/NSIS/Bin:$PATH
           mkdir -p /mnt/c/opt/local64/pgm/
           cp -R wxWidgets /mnt/c/opt/local64/pgm/wxWidgets-${{ env.WXWIDGETS_VERSION }}
           tar -xzf ./otp_src.tar.gz

--- a/erts/etc/win32/nsis/Makefile
+++ b/erts/etc/win32/nsis/Makefile
@@ -25,7 +25,7 @@ include $(ERL_TOP)/make/$(TARGET)/otp.mk
 include $(ERL_TOP)/erts/vsn.mk
 
 VERSION_HEADER = erlang.nsh
-MAKENSIS = makensis.exe
+MAKENSIS = makensis
 MAKENSISFLAGS = /V2
 CUSTOM_MODERN=custom_modern.exe
 
@@ -79,7 +79,7 @@ OTP_VERSION_LONG=$(shell $(ERL_TOP)/bootstrap/bin/escript.exe vsn_number.escript
 YEAR=$(shell date +%Y)
 
 release_spec:
-	@NSIS_VER=`makensis.exe -version`; \
+	@NSIS_VER=`makensis -version`; \
 	case $$NSIS_VER in \
 	v2.* | v3.0 | v3.01) \
 	  echo "Unsupported NSIS version: $$NSIS_VER";;\

--- a/erts/etc/win32/nsis/Makefile
+++ b/erts/etc/win32/nsis/Makefile
@@ -82,7 +82,9 @@ release_spec:
 	@NSIS_VER=`makensis -version`; \
 	case $$NSIS_VER in \
 	v2.* | v3.0 | v3.01) \
-	  echo "Unsupported NSIS version: $$NSIS_VER";;\
+	  echo "Unsupported NSIS version: $$NSIS_VER";\
+		exit -1;\
+	  ;;\
 	v3.*) \
 	  echo '!define OTP_RELEASE "$(SYSTEM_VSN)"' > $(VERSION_HEADER);\
 	  echo '!define OTP_VERSION "$(OTP_VERSION)"' >> $(VERSION_HEADER);\
@@ -113,7 +115,9 @@ release_spec:
 	  echo "Running $(MAKENSIS) $(MAKENSISFLAGS) erlang20.nsi";\
 	  $(MAKENSIS) $(MAKENSISFLAGS) erlang20.nsi;;\
 	*) \
-	  echo "Unsupported NSIS version: $$NSIS_VER";;\
+	  echo "Unsupported NSIS version: $$NSIS_VER";\
+	  exit -1;\
+	  ;;\
 	esac	
 
 release_docs release_docs_spec docs:

--- a/erts/etc/win32/nsis/Makefile
+++ b/erts/etc/win32/nsis/Makefile
@@ -79,7 +79,7 @@ OTP_VERSION_LONG=$(shell $(ERL_TOP)/bootstrap/bin/escript.exe vsn_number.escript
 YEAR=$(shell date +%Y)
 
 release_spec:
-	@NSIS_VER=`makensis -version`; \
+	@NSIS_VER=`makensis.exe -version`; \
 	case $$NSIS_VER in \
 	v2.* | v3.0 | v3.01) \
 	  echo "Unsupported NSIS version: $$NSIS_VER";\


### PR DESCRIPTION
windows-2022 came with makensis but windows-2025 removed it.

Notes here:
- https://github.com/actions/runner-images/issues/12677